### PR TITLE
各部屋のチャット履歴を格納するテーブルの作成

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,9 @@
+server.pord=8080
+spring.datasource.sql-script-encoding=UTF-8
+spring.datasource.url=jdbc:h2:mem:team4
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.h2.console.enabled:true
 
+logging.level.root=INFO

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,11 @@
+CREATE TABLE Room1 (
+  id IDENTITY,
+  user CHAR NOT NULL,
+  chatlog CHAR NOT NULL
+);
+
+CREATE TABLE Room2 (
+  id IDENTITY,
+  user CHAR NOT NULL,
+  chatlog CHAR NOT NULL
+);


### PR DESCRIPTION
application.propertiesにDBを扱うための処理を追記．
各部屋でのチャットの履歴を格納するdata.sqlを作成．
テーブル名は「Room1」,「Room2」の2つ．
カラムはid(IDENTITY), user(NOT NULL), chatlog(NOT NULL)の3つ．
